### PR TITLE
Widen type arguments for checked exceptions.

### DIFF
--- a/src/main/java/info/solidsoft/mockito/java8/AssertionMatcher.java
+++ b/src/main/java/info/solidsoft/mockito/java8/AssertionMatcher.java
@@ -81,7 +81,7 @@ public class AssertionMatcher<T> implements ArgumentMatcher<T> {
 
     public static <T> T assertArgChecked(CheckedConsumer<T> checkedConsumer) {
         argThat(checkedConsumer.uncheck());
-        return handyReturnValues.returnForConsumerLambda(checkedConsumer);
+        return handyReturnValues.returnForConsumerLambdaChecked(checkedConsumer);
     }
 
     @SuppressWarnings("ResultOfMethodCallIgnored")

--- a/src/main/java/info/solidsoft/mockito/java8/AssertionMatcher.java
+++ b/src/main/java/info/solidsoft/mockito/java8/AssertionMatcher.java
@@ -8,8 +8,6 @@ package info.solidsoft.mockito.java8;
 import org.mockito.ArgumentMatcher;
 import org.mockito.Mockito;
 
-import java.util.function.Consumer;
-
 /**
  * Allows creating inlined ArgumentCaptor with a lambda expression.
  * <p>
@@ -39,7 +37,7 @@ import java.util.function.Consumer;
  * }
  *
  * AssertJ assertions (assertThat()) used in lambda generate meaningful error messages in face of failure, but any other assertion can be
- * used if needed/preffered.
+ * used if needed/preferred.
  *
  * @param <T> type of argument
  *
@@ -49,10 +47,10 @@ public class AssertionMatcher<T> implements ArgumentMatcher<T> {
 
     private static final LambdaAwareHandyReturnValues handyReturnValues = new LambdaAwareHandyReturnValues();
 
-    private final Consumer<T> consumer;
+    private final CheckedConsumer<T> consumer;
     private String errorMessage;
 
-    private AssertionMatcher(Consumer<T> consumer) {
+    private AssertionMatcher(CheckedConsumer<T> consumer) {
         this.consumer = consumer;
     }
 
@@ -62,7 +60,7 @@ public class AssertionMatcher<T> implements ArgumentMatcher<T> {
         try {
             consumer.accept(argument);
             return true;
-        } catch (AssertionError e) {
+        } catch (AssertionError | Exception e) {
             errorMessage = e.getMessage();
             return false;
         }
@@ -73,7 +71,7 @@ public class AssertionMatcher<T> implements ArgumentMatcher<T> {
         return "AssertionMatcher reported: " + errorMessage;
     }
 
-    public static <T> T assertArg(Consumer<T> consumer) {
+    public static <T> T assertArg(CheckedConsumer<T> consumer) {
         Mockito.argThat(new AssertionMatcher<>(consumer));
         return handyReturnValues.returnForConsumerLambda(consumer);
     }

--- a/src/main/java/info/solidsoft/mockito/java8/AssertionMatcher.java
+++ b/src/main/java/info/solidsoft/mockito/java8/AssertionMatcher.java
@@ -45,39 +45,27 @@ import java.util.function.Consumer;
  *
  * @author Marcin Zajączkowski
  */
+@SuppressWarnings("WeakerAccess")
 public class AssertionMatcher<T> implements ArgumentMatcher<T> {
 
     private static final LambdaAwareHandyReturnValues handyReturnValues = new LambdaAwareHandyReturnValues();
 
     private final Consumer<T> consumer;
-    private final CheckedConsumer<T> checkedConsumer;
     private String errorMessage;
 
     private AssertionMatcher(Consumer<T> consumer) {
         this.consumer = consumer;
-        this.checkedConsumer = null;
-    }
-
-    private AssertionMatcher(CheckedConsumer<T> checkedConsumer) {
-        this.consumer = null;
-        this.checkedConsumer = checkedConsumer;
     }
 
     @SuppressWarnings("unchecked")
     @Override
     public boolean matches(T argument) {
         try {
-            if (consumer != null) {
-                consumer.accept(argument);
-            } else {
-                checkedConsumer.accept(argument);
-            }
+            consumer.accept(argument);
             return true;
         } catch (AssertionError e) {
             errorMessage = e.getMessage();
             return false;
-        } catch (Exception e) {
-            throw new RuntimeException(e);
         }
     }
 
@@ -87,12 +75,17 @@ public class AssertionMatcher<T> implements ArgumentMatcher<T> {
     }
 
     public static <T> T assertArg(Consumer<T> consumer) {
-        Mockito.argThat(new AssertionMatcher<>(consumer));
+        argThat(consumer);
         return handyReturnValues.returnForConsumerLambda(consumer);
     }
 
     public static <T> T assertArgChecked(CheckedConsumer<T> checkedConsumer) {
-        Mockito.argThat(new AssertionMatcher<>(checkedConsumer));
+        argThat(checkedConsumer.uncheck());
         return handyReturnValues.returnForConsumerLambda(checkedConsumer);
+    }
+
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    private static <T> void argThat(Consumer<T> consumer) {
+        Mockito.argThat(new AssertionMatcher<>(consumer));
     }
 }

--- a/src/main/java/info/solidsoft/mockito/java8/CheckedConsumer.java
+++ b/src/main/java/info/solidsoft/mockito/java8/CheckedConsumer.java
@@ -1,6 +1,32 @@
+/*
+ * Copyright (C) 2018 Mockito contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
 package info.solidsoft.mockito.java8;
+
+import java.util.function.Consumer;
 
 @FunctionalInterface
 public interface CheckedConsumer<T> {
-    void accept(T var1) throws Exception;
+
+    void accept(T t) throws Exception;
+
+    default Consumer<T> uncheck() {
+        return this::trickCompilerToAcceptLackOfDeclarationOfCheckedException;
+    }
+
+    /**
+     * A hack to trick the compiler to accept a lack of a declaration of checked exception in a caller.
+     *
+     * Based on the idea presented by Grzegorz Piwowarek in his presentation: The Dark Side of Java 8.
+     */
+    @SuppressWarnings("unchecked")
+    /*private */ default <E extends Exception> void trickCompilerToAcceptLackOfDeclarationOfCheckedException(T t) throws E {
+        try {
+            this.accept(t);
+        } catch (Exception e) {
+            throw (E) e;
+        }
+    }
 }

--- a/src/main/java/info/solidsoft/mockito/java8/CheckedConsumer.java
+++ b/src/main/java/info/solidsoft/mockito/java8/CheckedConsumer.java
@@ -1,0 +1,6 @@
+package info.solidsoft.mockito.java8;
+
+@FunctionalInterface
+public interface CheckedConsumer<T> {
+    void accept(T var1) throws Exception;
+}

--- a/src/main/java/info/solidsoft/mockito/java8/CheckedPredicate.java
+++ b/src/main/java/info/solidsoft/mockito/java8/CheckedPredicate.java
@@ -1,6 +1,32 @@
+/*
+ * Copyright (C) 2018 Mockito contributors.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
 package info.solidsoft.mockito.java8;
+
+import java.util.function.Predicate;
 
 @FunctionalInterface
 public interface CheckedPredicate<T> {
-    boolean test(T var1) throws Exception;
+
+    boolean test(T t) throws Exception;
+
+    default Predicate<T> uncheck() {
+        return this::trickCompilerToAcceptLackOfDeclarationOfCheckedException;
+    }
+
+    /**
+     * A hack to trick the compiler to accept a lack of a declaration of checked exception in a caller.
+     *
+     * Based on the idea presented by Grzegorz Piwowarek in his presentation: The Dark Side of Java 8.
+     */
+    @SuppressWarnings("unchecked")
+    /*private */ default <E extends Exception> boolean trickCompilerToAcceptLackOfDeclarationOfCheckedException(T t) throws E {
+        try {
+            return this.test(t);
+        } catch (Exception e) {
+            throw (E) e;
+        }
+    }
 }

--- a/src/main/java/info/solidsoft/mockito/java8/CheckedPredicate.java
+++ b/src/main/java/info/solidsoft/mockito/java8/CheckedPredicate.java
@@ -1,0 +1,6 @@
+package info.solidsoft.mockito.java8;
+
+@FunctionalInterface
+public interface CheckedPredicate<T> {
+    boolean test(T var1) throws Exception;
+}

--- a/src/main/java/info/solidsoft/mockito/java8/LambdaAwareHandyReturnValues.java
+++ b/src/main/java/info/solidsoft/mockito/java8/LambdaAwareHandyReturnValues.java
@@ -8,6 +8,8 @@ package info.solidsoft.mockito.java8;
 import net.jodah.typetools.TypeResolver;
 import org.mockito.internal.util.Primitives;
 
+import java.util.function.Consumer;
+
 /**
  * Extended version of HandyReturnValues which can resolve safe return type also for Consumer argument.
  *
@@ -16,10 +18,15 @@ import org.mockito.internal.util.Primitives;
  * @author Marcin Zajączkowski
  */
 class LambdaAwareHandyReturnValues {
+    @SuppressWarnings("unchecked")
+    <T> T returnForConsumerLambda(Consumer<T> consumer) {
+        Class<?>[] typeArgs = TypeResolver.resolveRawArguments(CheckedConsumer.class, consumer.getClass());
+        return (T) Primitives.defaultValue(typeArgs[0]);
+    }
 
     @SuppressWarnings("unchecked")
-    <T> T returnForConsumerLambda(CheckedConsumer<T> consumer) {
-        Class<?>[] typeArgs = TypeResolver.resolveRawArguments(CheckedConsumer.class, consumer.getClass());
+    <T> T returnForConsumerLambda(CheckedConsumer<T> checkedConsumer) {
+        Class<?>[] typeArgs = TypeResolver.resolveRawArguments(CheckedConsumer.class, checkedConsumer.getClass());
         return (T) Primitives.defaultValue(typeArgs[0]);
     }
 }

--- a/src/main/java/info/solidsoft/mockito/java8/LambdaAwareHandyReturnValues.java
+++ b/src/main/java/info/solidsoft/mockito/java8/LambdaAwareHandyReturnValues.java
@@ -23,7 +23,7 @@ class LambdaAwareHandyReturnValues {
         return internalReturnForLambda(consumer, Consumer.class);
     }
 
-    <T> T returnForConsumerLambda(CheckedConsumer<T> checkedConsumer) {
+    <T> T returnForConsumerLambdaChecked(CheckedConsumer<T> checkedConsumer) {
         return internalReturnForLambda(checkedConsumer, CheckedConsumer.class);
     }
 

--- a/src/main/java/info/solidsoft/mockito/java8/LambdaAwareHandyReturnValues.java
+++ b/src/main/java/info/solidsoft/mockito/java8/LambdaAwareHandyReturnValues.java
@@ -18,15 +18,18 @@ import java.util.function.Consumer;
  * @author Marcin Zajączkowski
  */
 class LambdaAwareHandyReturnValues {
-    @SuppressWarnings("unchecked")
+
     <T> T returnForConsumerLambda(Consumer<T> consumer) {
-        Class<?>[] typeArgs = TypeResolver.resolveRawArguments(CheckedConsumer.class, consumer.getClass());
-        return (T) Primitives.defaultValue(typeArgs[0]);
+        return internalReturnForLambda(consumer, Consumer.class);
+    }
+
+    <T> T returnForConsumerLambda(CheckedConsumer<T> checkedConsumer) {
+        return internalReturnForLambda(checkedConsumer, CheckedConsumer.class);
     }
 
     @SuppressWarnings("unchecked")
-    <T> T returnForConsumerLambda(CheckedConsumer<T> checkedConsumer) {
-        Class<?>[] typeArgs = TypeResolver.resolveRawArguments(CheckedConsumer.class, checkedConsumer.getClass());
+    private <T> T internalReturnForLambda(Object consumer, Class consumerType) {
+        Class<?>[] typeArgs = TypeResolver.resolveRawArguments(consumerType, consumer.getClass());
         return (T) Primitives.defaultValue(typeArgs[0]);
     }
 }

--- a/src/main/java/info/solidsoft/mockito/java8/LambdaAwareHandyReturnValues.java
+++ b/src/main/java/info/solidsoft/mockito/java8/LambdaAwareHandyReturnValues.java
@@ -8,8 +8,6 @@ package info.solidsoft.mockito.java8;
 import net.jodah.typetools.TypeResolver;
 import org.mockito.internal.util.Primitives;
 
-import java.util.function.Consumer;
-
 /**
  * Extended version of HandyReturnValues which can resolve safe return type also for Consumer argument.
  *
@@ -20,8 +18,8 @@ import java.util.function.Consumer;
 class LambdaAwareHandyReturnValues {
 
     @SuppressWarnings("unchecked")
-    <T> T returnForConsumerLambda(Consumer<T> consumer) {
-        Class<?>[] typeArgs = TypeResolver.resolveRawArguments(Consumer.class, consumer.getClass());
+    <T> T returnForConsumerLambda(CheckedConsumer<T> consumer) {
+        Class<?>[] typeArgs = TypeResolver.resolveRawArguments(CheckedConsumer.class, consumer.getClass());
         return (T) Primitives.defaultValue(typeArgs[0]);
     }
 }

--- a/src/main/java/info/solidsoft/mockito/java8/LambdaMatcher.java
+++ b/src/main/java/info/solidsoft/mockito/java8/LambdaMatcher.java
@@ -7,8 +7,6 @@ package info.solidsoft.mockito.java8;
 
 import org.mockito.ArgumentMatcher;
 
-import java.util.function.Predicate;
-
 import static org.mockito.ArgumentMatchers.argThat;
 
 /**
@@ -78,7 +76,7 @@ public class LambdaMatcher<T> implements ArgumentMatcher<T> {
 
     private final ArgumentMatcher<T> backendMatcher;    //TODO: Could it be done with just one matcher?
 
-    private LambdaMatcher(Predicate<T> lambda, String description) {
+    private LambdaMatcher(CheckedPredicate<T> lambda, String description) {
         this.backendMatcher = new ArgumentMatcher<T>() {
             @SuppressWarnings("unchecked")
             @Override
@@ -107,11 +105,11 @@ public class LambdaMatcher<T> implements ArgumentMatcher<T> {
         return backendMatcher.toString();
     }
 
-    public static <T> T argLambda(Predicate<T> lambda) {
+    public static <T> T argLambda(CheckedPredicate<T> lambda) {
         return argLambda(lambda, "Inline lambda expression - add description in code to get more detailed error message");
     }
 
-    public static <T> T argLambda(Predicate<T> lambda, String description) {
+    public static <T> T argLambda(CheckedPredicate<T> lambda, String description) {
         return argThat(new LambdaMatcher<>(lambda, description));
     }
 }

--- a/src/test/java/info/solidsoft/mockito/java8/AssertionMatcherTest.java
+++ b/src/test/java/info/solidsoft/mockito/java8/AssertionMatcherTest.java
@@ -17,6 +17,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import static info.solidsoft.mockito.java8.AssertionMatcher.assertArg;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)  //MockitoRule is not used to build also Mockito version before 1.10.17
@@ -74,5 +75,13 @@ public class AssertionMatcherTest {
                         "ts.findNumberOfShipsInRangeByCriteria(\n" +
                         "    ShipSearchCriteria{minimumRange=1000, numberOfPhasers=4}\n" +
                         ");");
+    }
+
+    @Test
+    public void shouldAllowToUseAnyExceptionAsFailedAssertion() {
+        //when
+        ts.fireTorpedo(2);
+        //then
+        verify(ts, never()).fireTorpedo(assertArg(i -> { throw new Exception("assertion failed"); }));
     }
 }

--- a/src/test/java/info/solidsoft/mockito/java8/AssertionMatcherTest.java
+++ b/src/test/java/info/solidsoft/mockito/java8/AssertionMatcherTest.java
@@ -15,9 +15,9 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import static info.solidsoft.mockito.java8.AssertionMatcher.assertArg;
+import static info.solidsoft.mockito.java8.AssertionMatcher.assertArgChecked;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)  //MockitoRule is not used to build also Mockito version before 1.10.17
@@ -77,11 +77,11 @@ public class AssertionMatcherTest {
                         ");");
     }
 
-    @Test
-    public void shouldAllowToUseAnyExceptionAsFailedAssertion() {
+    @Test(expected = RuntimeException.class)
+    public void shouldWrapAnyExceptionAsRuntimeException() {
         //when
         ts.fireTorpedo(2);
         //then
-        verify(ts, never()).fireTorpedo(assertArg(i -> { throw new Exception("assertion failed"); }));
+        verify(ts).fireTorpedo(assertArgChecked(i -> { throw new Exception("assertion failed"); }));
     }
 }

--- a/src/test/java/info/solidsoft/mockito/java8/AssertionMatcherTest.java
+++ b/src/test/java/info/solidsoft/mockito/java8/AssertionMatcherTest.java
@@ -14,6 +14,8 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import java.io.IOException;
+
 import static info.solidsoft.mockito.java8.AssertionMatcher.assertArg;
 import static info.solidsoft.mockito.java8.AssertionMatcher.assertArgChecked;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -77,11 +79,32 @@ public class AssertionMatcherTest {
                         ");");
     }
 
-    @Test(expected = RuntimeException.class)
-    public void shouldWrapAnyExceptionAsRuntimeException() {
+    @SuppressWarnings("Convert2MethodRef")
+    @Test
+    public void shouldAcceptLambdaWhichMayThrowCheckedException() {
         //when
         ts.fireTorpedo(2);
         //then
-        verify(ts).fireTorpedo(assertArgChecked(i -> { throw new Exception("assertion failed"); }));
+        verify(ts).fireTorpedo(assertArgChecked(i -> methodDeclaringThrowingCheckedException(i)));
+    }
+
+    @Test
+    public void shouldAcceptMethodReferenceWhichMayThrowCheckedException() {
+        //when
+        ts.fireTorpedo(2);
+        //then
+        verify(ts).fireTorpedo(assertArgChecked(this::methodDeclaringThrowingCheckedException));
+    }
+
+    @Test(expected = IOException.class)
+    public void shouldPropagateCheckedExceptionIfThrownInLambda() {
+        //when
+        ts.fireTorpedo(2);
+        //then
+        verify(ts).fireTorpedo(assertArgChecked(i -> { throw new IOException("Unexpected checked exception"); }));
+    }
+
+    private void methodDeclaringThrowingCheckedException(int i) throws Exception {
+        assertThat(i).isEqualTo(2);
     }
 }

--- a/src/test/java/info/solidsoft/mockito/java8/LambdaMatcherTest.java
+++ b/src/test/java/info/solidsoft/mockito/java8/LambdaMatcherTest.java
@@ -17,6 +17,7 @@ import org.mockito.internal.hamcrest.HamcrestArgumentMatcher;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import static info.solidsoft.mockito.java8.LambdaMatcher.argLambda;
+import static info.solidsoft.mockito.java8.LambdaMatcher.argLambdaChecked;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -141,12 +142,12 @@ public class LambdaMatcherTest {
     }
 
     @Test(expected = RuntimeException.class)
-    public void shouldAllowToUseAnyCheckedExceptionAsError() {
+    public void shouldWrapAnyExceptionAsRuntimeException() {
         //when
         int numberOfShips = ts.findNumberOfShipsInRangeByCriteria(searchCriteria);
         //then
         assertThat(numberOfShips).isZero();
         //and
-        verify(ts).findNumberOfShipsInRangeByCriteria(argLambda(c -> { throw new Exception("assertion failed"); }));
+        verify(ts).findNumberOfShipsInRangeByCriteria(argLambdaChecked(c -> { throw new Exception("assertion failed"); }, "won't happen"));
     }
 }

--- a/src/test/java/info/solidsoft/mockito/java8/LambdaMatcherTest.java
+++ b/src/test/java/info/solidsoft/mockito/java8/LambdaMatcherTest.java
@@ -139,4 +139,14 @@ public class LambdaMatcherTest {
                         ");");
 
     }
+
+    @Test(expected = RuntimeException.class)
+    public void shouldAllowToUseAnyCheckedExceptionAsError() {
+        //when
+        int numberOfShips = ts.findNumberOfShipsInRangeByCriteria(searchCriteria);
+        //then
+        assertThat(numberOfShips).isZero();
+        //and
+        verify(ts).findNumberOfShipsInRangeByCriteria(argLambda(c -> { throw new Exception("assertion failed"); }));
+    }
 }


### PR DESCRIPTION
Fixes <https://github.com/szpak/mockito-java8/issues/12>.

Added two tests two check for the behaviour, the rest still passes (only tested
on Java 8).